### PR TITLE
MAINT: stats.boxcox_normmax: make default ymax value appear as BIG_FLOAT

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1336,7 +1336,6 @@ def boxcox_normmax(
                    "an object containing the optimal `lmbda` in attribute `x`.")
         raise ValueError(message)
     elif not np.isinf(ymax):  # adjust the final lambda
-        x = np.asarray(x)
         xmax = np.max(x, axis=0)
         ymax_res = special.boxcox(xmax, res)
         mask = ymax_res > ymax

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1133,8 +1133,17 @@ def _boxcox_inv_lmbda(x, y):
     return np.real(-num / np.log(x) - 1 / y)
 
 
+class BigFloat:
+    def __repr__(self):
+        return "BIG_FLOAT"
+
+    def __call__(self, x):
+        dtype = x.dtype if np.issubdtype(x.dtype, np.floating) else np.float64
+        return np.finfo(dtype).max / 100  # 100 is the safety factor
+
+
 def boxcox_normmax(
-    x, brack=None, method='pearsonr', optimizer=None, *, ymax=None
+    x, brack=None, method='pearsonr', optimizer=None, *, ymax=BigFloat()
 ):
     """Compute optimal Box-Cox transform parameter for input data.
 
@@ -1180,12 +1189,12 @@ def boxcox_normmax(
         See the example below or the documentation of
         `scipy.optimize.minimize_scalar` for more information.
     ymax : float, optional
-        This parameter constraints the maximum returned `maxlog` such that
-        the Box-Cox transformation of the maximum `x` is at most `ymax`.
-        This helps to avoid situations where the maximum transformed `x`
-        overflows with the optimal value of `maxlog`. The default value
-        is the maximum value of the input dtype. If set to infinity,
-        it returns the true, unconstrained optimal lambda.
+        The unconstrained optimal transform parameter may cause Box-Cox
+        transformed data to have extreme magnitude or even overflow. This
+        parameter constrains MLE optimization such that the transformed
+        `x` does not exceed `ymax`. The default is the maximum value of the
+        input dtype. If set to infinity, `boxcox_normmax` returns the
+        unconstrained optimal lambda. Ignored when ``method='pearsonr'``.
 
     Returns
     -------
@@ -1242,7 +1251,12 @@ def boxcox_normmax(
     >>> stats.boxcox_normmax(x, optimizer=optimizer)
     6.000...
     """
-    if ymax is not None and ymax <= 0:
+    x = np.asarray(x)
+    end_msg = "exceed specified `ymax`."
+    if isinstance(ymax, BigFloat):
+        ymax = ymax(x)
+        end_msg = f"overflow."
+    elif ymax <= 0:
         raise ValueError("`ymax` must be strictly positive")
 
     # If optimizer is not given, define default 'brent' optimizer.
@@ -1321,19 +1335,10 @@ def boxcox_normmax(
         message = ("The `optimizer` argument of `boxcox_normmax` must return "
                    "an object containing the optimal `lmbda` in attribute `x`.")
         raise ValueError(message)
-    elif ymax is None or not np.isinf(ymax):  # adjust the final lambda
+    elif not np.isinf(ymax):  # adjust the final lambda
         x = np.asarray(x)
         xmax = np.max(x, axis=0)
         ymax_res = special.boxcox(xmax, res)
-
-        if ymax is None:
-            # The default `ymax` is the maximum value of the input dtype
-            dtype = x.dtype if np.issubdtype(x.dtype, np.floating) else np.float64
-            ymax = np.finfo(dtype).max / 100  # 100 is the safety factor
-            end_msg = f"cause overflow in {dtype}."
-        else:
-            end_msg = "exceed specified `ymax`."
-
         mask = ymax_res > ymax
         if np.any(mask):
             message = (

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1129,7 +1129,7 @@ def boxcox(x, lmbda=None, alpha=None, optimizer=None):
 
 def _boxcox_inv_lmbda(x, y):
     # compute lmbda given x and y for Box-Cox transformation
-    num = special.lambertw(-(x ** (-1 / y)) * np.log(x) / y, k=1)
+    num = special.lambertw(-(x ** (-1 / y)) * np.log(x) / y, k=-1)
     return np.real(-num / np.log(x) - 1 / y)
 
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2092,13 +2092,14 @@ class TestBoxcoxNormmax:
         np.array([2003.0e200, 1950.0e200, 1997.0e200, 2000.0e200, 2009.0e200],
                  dtype=np.float64)
     ])
-    @pytest.mark.parametrize("ymax", [1e10, 1e30, 1e100, None])
+    @pytest.mark.parametrize("ymax", [1e10, 1e100, None])
     # TODO: add method "pearsonr" after fix overflow issue
     @pytest.mark.parametrize("method", ["mle"])
     def test_user_defined_ymax_input_float64(self, x, ymax, method):
         # Test the maximum of the transformed data close to ymax
         with pytest.warns(UserWarning, match="The optimal lambda is"):
-            lmb = stats.boxcox_normmax(x, ymax=ymax, method=method)
+            kwarg = {'ymax': ymax} if ymax is not None else {}
+            lmb = stats.boxcox_normmax(x, method=method, **kwarg)
             ymax_res = stats.boxcox(np.max(x), lmb)
             if ymax is None:
                 ymax = np.finfo(x.dtype).max / 100
@@ -2116,13 +2117,14 @@ class TestBoxcoxNormmax:
         np.array([200.3, 195.0, 199.7, 200.0, 200.9],
                  dtype=np.float32)
     ])
-    @pytest.mark.parametrize("ymax", [1e8, 1e15, 1e30, None])
+    @pytest.mark.parametrize("ymax", [1e8, 1e30, None])
     # TODO: add method "pearsonr" after fix overflow issue
     @pytest.mark.parametrize("method", ["mle"])
     def test_user_defined_ymax_input_float32(self, x, ymax, method):
         # Test the maximum of the transformed data close to ymax
         with pytest.warns(UserWarning, match="The optimal lambda is"):
-            lmb = stats.boxcox_normmax(x, ymax=ymax, method=method)
+            kwarg = {'ymax': ymax} if ymax is not None else {}
+            lmb = stats.boxcox_normmax(x, method=method, **kwarg)
             ymax_res = stats.boxcox(np.max(x), lmb)
             if ymax is None:
                 ymax = np.finfo(x.dtype).max / 100


### PR DESCRIPTION
Re: https://github.com/scipy/scipy/pull/19631/files#r1414500609. The intent is to make the signature look like `ymax=BIG_FLOAT` (because `ymax=None` suggests that there is no finite `ymax`; i.e. `ymax=np,inf`).
